### PR TITLE
add comparison filters

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,6 +61,9 @@ BUILT_SOURCES := $(asynchbase_PROTOS:protobuf/%.proto=$(PROTOBUF_GEN_DIR)/%PB.ja
 asynchbase_SOURCES := \
 	src/AtomicIncrementRequest.java	\
 	src/BatchableRpc.java	\
+	src/BinaryComparator.java	\
+	src/BinaryPrefixComparator.java	\
+	src/BitComparator.java	\
 	src/BrokenMetaException.java	\
 	src/BufferedIncrement.java	\
 	src/Bytes.java	\
@@ -68,9 +71,13 @@ asynchbase_SOURCES := \
 	src/ColumnPrefixFilter.java	\
 	src/ColumnRangeFilter.java	\
 	src/CompareAndSetRequest.java	\
+	src/CompareFilter.java	\
 	src/ConnectionResetException.java	\
 	src/Counter.java	\
 	src/DeleteRequest.java	\
+	src/DependentColumnFilter.java	\
+	src/FamilyFilter.java	\
+	src/FilterComparator.java	\
 	src/FilterList.java		\
 	src/GetRequest.java	\
 	src/HBaseClient.java	\
@@ -86,19 +93,25 @@ asynchbase_SOURCES := \
 	src/NotServingRegionException.java	\
 	src/PleaseThrottleException.java	\
 	src/PutRequest.java	\
+	src/QualifierFilter.java	\
 	src/RecoverableException.java	\
+	src/RegexStringComparator.java	\
 	src/RegionClient.java	\
 	src/RegionInfo.java	\
 	src/RegionOfflineException.java	\
 	src/RemoteException.java	\
+	src/RowFilter.java	\
+	src/RowFilter.java	\
 	src/RowLock.java	\
 	src/RowLockRequest.java	\
 	src/ScanFilter.java	\
 	src/Scanner.java	\
 	src/SingletonList.java	\
+	src/SubstringComparator.java	\
 	src/TableNotFoundException.java	\
 	src/UnknownRowLockException.java	\
 	src/UnknownScannerException.java	\
+	src/ValueFilter.java	\
 	src/VersionMismatchException.java	\
 	src/jsr166e/LongAdder.java	\
 	src/jsr166e/Striped64.java	\

--- a/src/BinaryComparator.java
+++ b/src/BinaryComparator.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright (C) 2012  The Async HBase Authors.  All rights reserved.
+ * This file is part of Async HBase.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *   - Redistributions of source code must retain the above copyright notice,
+ *     this list of conditions and the following disclaimer.
+ *   - Redistributions in binary form must reproduce the above copyright notice,
+ *     this list of conditions and the following disclaimer in the documentation
+ *     and/or other materials provided with the distribution.
+ *   - Neither the name of the StumbleUpon nor the names of its contributors
+ *     may be used to endorse or promote products derived from this software
+ *     without specific prior written permission.
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hbase.async;
+
+import com.google.protobuf.ByteString;
+import org.jboss.netty.buffer.ChannelBuffer;
+
+import org.hbase.async.generated.ComparatorPB;
+
+/**
+ * A binary comparator used in comparison filters. Compares byte arrays
+ * lexicographically.
+ * @since 1.5
+ */
+public class BinaryComparator extends FilterComparator {
+
+  private static final byte[] NAME =
+      Bytes.UTF8("org.apache.hadoop.hbase.filter.BinaryComparator");
+  private static final byte CODE = 47;
+
+  private final byte[] value;
+
+  public BinaryComparator(byte[] value) {
+    this.value = value;
+  }
+
+  public byte[] value() {
+    return value.clone();
+  }
+
+  @Override
+  byte[] name() {
+    return NAME;
+  }
+
+  @Override
+  ComparatorPB.Comparator toProtobuf() {
+    ByteString byte_string = ComparatorPB
+      .BinaryComparator
+      .newBuilder()
+      .setComparable(
+          ComparatorPB
+            .ByteArrayComparable
+            .newBuilder()
+            .setValue(Bytes.wrap(value)))
+      .build()
+      .toByteString();
+    return super.toProtobuf(byte_string);
+  }
+
+  @Override
+  void serializeOld(ChannelBuffer buf) {
+    super.serializeOld(buf);              // super.predictSerializedSize()
+    // Write class code
+    buf.writeByte(CODE);                  // 1
+    // Write value
+    HBaseRpc.writeByteArray(buf, value);  // 3 + value.length
+  }
+
+  @Override
+  int predictSerializedSize() {
+    return 1 + 3 + value.length;
+  }
+
+  @Override
+  public String toString() {
+    return String.format("%s(%s)",
+        getClass().getSimpleName(),
+        Bytes.pretty(value));
+  }
+}

--- a/src/BinaryPrefixComparator.java
+++ b/src/BinaryPrefixComparator.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright (C) 2012  The Async HBase Authors.  All rights reserved.
+ * This file is part of Async HBase.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *   - Redistributions of source code must retain the above copyright notice,
+ *     this list of conditions and the following disclaimer.
+ *   - Redistributions in binary form must reproduce the above copyright notice,
+ *     this list of conditions and the following disclaimer in the documentation
+ *     and/or other materials provided with the distribution.
+ *   - Neither the name of the StumbleUpon nor the names of its contributors
+ *     may be used to endorse or promote products derived from this software
+ *     without specific prior written permission.
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hbase.async;
+
+import com.google.protobuf.ByteString;
+import org.jboss.netty.buffer.ChannelBuffer;
+
+import org.hbase.async.generated.ComparatorPB;
+
+/**
+ * A binary comparator used in comparison filters. Compares byte arrays
+ * lexicographically up to the length of the provided byte array.
+ * @since 1.5
+ */
+public class BinaryPrefixComparator extends FilterComparator {
+
+  private static final byte[] NAME =
+      Bytes.UTF8("org.apache.hadoop.hbase.filter.BinaryPrefixComparator");
+  private static final byte CODE = 47;
+
+  private final byte[] value;
+
+  public BinaryPrefixComparator(byte[] value) {
+    this.value = value;
+  }
+
+  public byte[] value() {
+    return value.clone();
+  }
+
+  @Override
+  byte[] name() {
+    return NAME;
+  }
+
+  @Override
+  ComparatorPB.Comparator toProtobuf() {
+    ByteString byte_string = ComparatorPB
+        .BinaryPrefixComparator
+        .newBuilder()
+        .setComparable(
+            ComparatorPB
+                .ByteArrayComparable
+                .newBuilder()
+                .setValue(Bytes.wrap(value)))
+        .build()
+        .toByteString();
+    return super.toProtobuf(byte_string);
+  }
+
+  @Override
+  void serializeOld(ChannelBuffer buf) {
+    super.serializeOld(buf);              // super.predictSerializedSize()
+    // Write class code
+    buf.writeByte(CODE);                  // 1
+    // Write value
+    HBaseRpc.writeByteArray(buf, value);  // 3 + value.length
+  }
+
+  @Override
+  int predictSerializedSize() {
+    return super.predictSerializedSize() + 1 + 3 + value.length;
+  }
+
+  @Override
+  public String toString() {
+    return String.format("%s(%s)",
+        getClass().getSimpleName(),
+        Bytes.pretty(value));
+  }
+}

--- a/src/BitComparator.java
+++ b/src/BitComparator.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright (C) 2012  The Async HBase Authors.  All rights reserved.
+ * This file is part of Async HBase.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *   - Redistributions of source code must retain the above copyright notice,
+ *     this list of conditions and the following disclaimer.
+ *   - Redistributions in binary form must reproduce the above copyright notice,
+ *     this list of conditions and the following disclaimer in the documentation
+ *     and/or other materials provided with the distribution.
+ *   - Neither the name of the StumbleUpon nor the names of its contributors
+ *     may be used to endorse or promote products derived from this software
+ *     without specific prior written permission.
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hbase.async;
+
+import com.google.protobuf.ByteString;
+import org.jboss.netty.buffer.ChannelBuffer;
+
+import org.hbase.async.generated.ComparatorPB;
+
+/**
+ * A bitwise comparator used in comparison filters. Performs the specified
+ * bitwise operation on each of the bytes with the specified byte array.
+ * Returns whether the result is non-zero.
+ * <p>
+ * Only EQUAL and NOT_EQUAL comparisons are valid with this comparator.
+ * @since 1.5
+ */
+public class BitComparator extends FilterComparator {
+
+  /** Bit operators. */
+  public enum BitwiseOp {
+    /** and */
+    AND,
+    /** or */
+    OR,
+    /** xor */
+    XOR
+  }
+
+  private static final byte[] NAME =
+      Bytes.UTF8("org.apache.hadoop.hbase.filter.BitComparator");
+  private static final byte CODE = 48;
+
+  private final byte[] value;
+  private final BitwiseOp bit_operator;
+
+  public BitComparator(byte[] value, BitwiseOp bitOperator) {
+    this.value = value;
+    this.bit_operator = bitOperator;
+  }
+
+  public byte[] value() {
+    return value.clone();
+  }
+
+  public BitwiseOp bitwiseOperator() {
+    return bit_operator;
+  }
+
+  @Override
+  byte[] name() {
+    return NAME;
+  }
+
+  @Override
+  ComparatorPB.Comparator toProtobuf() {
+    ByteString byte_string = ComparatorPB
+        .BitComparator
+        .newBuilder()
+        .setComparable(
+            ComparatorPB
+                .ByteArrayComparable
+                .newBuilder()
+                .setValue(Bytes.wrap(value)))
+        .setBitwiseOp(ComparatorPB
+            .BitComparator.BitwiseOp.valueOf(bit_operator.name()))
+        .build()
+        .toByteString();
+    return super.toProtobuf(byte_string);
+  }
+
+  @Override
+  void serializeOld(ChannelBuffer buf) {
+    super.serializeOld(buf);              // super.predictSerializedSize()
+    // Write class code
+    buf.writeByte(CODE);                  // 1
+    // Write value
+    HBaseRpc.writeByteArray(buf, value);  // 3 + value.length
+    // Write op
+    final byte[] op_name = Bytes.UTF8(bit_operator.name());
+    buf.writeShort(op_name.length);       // 2
+    buf.writeBytes(op_name);              // op_name.length
+  }
+
+  @Override
+  int predictSerializedSize() {
+    return 1 + 3 + value.length + 2 + Bytes.UTF8(bit_operator.name()).length;
+  }
+
+  @Override
+  public String toString() {
+    return String.format("%s(%s)",
+        getClass().getSimpleName(),
+        Bytes.pretty(value));
+  }
+}

--- a/src/CompareFilter.java
+++ b/src/CompareFilter.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright (C) 2012  The Async HBase Authors.  All rights reserved.
+ * This file is part of Async HBase.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *   - Redistributions of source code must retain the above copyright notice,
+ *     this list of conditions and the following disclaimer.
+ *   - Redistributions in binary form must reproduce the above copyright notice,
+ *     this list of conditions and the following disclaimer in the documentation
+ *     and/or other materials provided with the distribution.
+ *   - Neither the name of the StumbleUpon nor the names of its contributors
+ *     may be used to endorse or promote products derived from this software
+ *     without specific prior written permission.
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hbase.async;
+
+import org.jboss.netty.buffer.ChannelBuffer;
+
+import org.hbase.async.generated.ComparatorPB;
+import org.hbase.async.generated.FilterPB;
+import org.hbase.async.generated.HBasePB;
+
+/**
+ * A generic scan filter to be used to filter by comparison. It takes an
+ * operator (equal, greater, not equal, etc) and a filter comparator.
+ * @since 1.5
+ */
+public abstract class CompareFilter extends ScanFilter {
+
+  /** Comparison operators. */
+  public enum CompareOp {
+    /** less than */
+    LESS,
+    /** less than or equal to */
+    LESS_OR_EQUAL,
+    /** equals */
+    EQUAL,
+    /** not equal */
+    NOT_EQUAL,
+    /** greater than or equal to */
+    GREATER_OR_EQUAL,
+    /** greater than */
+    GREATER,
+    /** no operation */
+    NO_OP,
+  }
+
+  protected CompareOp compare_op;
+  protected FilterComparator comparator;
+
+  public CompareFilter(final CompareOp compareOp,
+                       final FilterComparator comparator) {
+    this.compare_op = compareOp;
+    this.comparator = comparator;
+  }
+
+  public CompareOp compareOperation() {
+      return compare_op;
+  }
+
+  public FilterComparator comparator() {
+      return comparator;
+  }
+
+  protected final FilterPB.CompareFilter toProtobuf() {
+    final FilterPB.CompareFilter.Builder builder =
+        FilterPB.CompareFilter.newBuilder();
+    final ComparatorPB.Comparator comparator_pb = comparator.toProtobuf();
+
+    if (comparator_pb != null) {
+      builder.setComparator(comparator_pb);
+    }
+
+    return builder
+        .setCompareOp(HBasePB.CompareType.valueOf(compare_op.name()))
+        .build();
+  }
+
+  abstract byte[] serialize();
+
+  @Override
+  void serializeOld(ChannelBuffer buf) {
+    // Write the filter name
+    buf.writeByte((byte) name().length);            // 1
+    buf.writeBytes(name());                         // name().length
+    // writeUTF comparison operation
+    buf.writeShort(compare_op.name().length());      // 2
+    buf.writeBytes(Bytes.UTF8(compare_op.name()));   // compare_op.name().length
+    // Write the comparator
+    comparator.serializeOld(buf);                   // comparator.predictSerializedSize()
+  }
+
+  @Override
+  int predictSerializedSize() {
+    return 1 + name().length
+         + 2 + compare_op.name().length()
+         + comparator.predictSerializedSize();
+  }
+
+  @Override
+  public String toString() {
+    return String.format("%s(%s, %s)",
+        getClass().getSimpleName(),
+        compare_op.name(),
+        comparator.toString());
+  }
+}

--- a/src/DependentColumnFilter.java
+++ b/src/DependentColumnFilter.java
@@ -1,0 +1,215 @@
+/*
+ * Copyright (C) 2012  The Async HBase Authors.  All rights reserved.
+ * This file is part of Async HBase.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *   - Redistributions of source code must retain the above copyright notice,
+ *     this list of conditions and the following disclaimer.
+ *   - Redistributions in binary form must reproduce the above copyright notice,
+ *     this list of conditions and the following disclaimer in the documentation
+ *     and/or other materials provided with the distribution.
+ *   - Neither the name of the StumbleUpon nor the names of its contributors
+ *     may be used to endorse or promote products derived from this software
+ *     without specific prior written permission.
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hbase.async;
+
+import org.jboss.netty.buffer.ChannelBuffer;
+
+import org.hbase.async.generated.ComparatorPB;
+import org.hbase.async.generated.FilterPB;
+
+/**
+ * Filters key values based on the existence of a dependent, or reference,
+ * column. Column values in a row will be filtered unless the row contains a
+ * value in the dependent column with the same time stamp.
+ * <p>
+ * A comparison can optionally be provided to further filter based on the value
+ * of the dependent column.
+ * @since 1.5
+ */
+public class DependentColumnFilter extends CompareFilter {
+
+  private static final byte[] NAME =
+      Bytes.UTF8("org.apache.hadoop.hbase.filter.DependentColumnFilter");
+
+  private final byte[] family;
+  private final byte[] qualifier;
+  private final boolean drop_dependent_column;
+
+  /**
+   * Create a DependentColumnFilter with the provided dependent column,
+   * additional value filter, and specification of whether the dependent
+   * column should be included in the results.
+   *
+   * @param family of dependent column.
+   * @param qualifier of dependent column.
+   * @param dropDependentColumn whether to include or exclude the dependent
+   *            column in the results.
+   * @param valueCompareOp of dependent-column value filter.
+   * @param valueComparator of dependent-column value filter.
+   */
+  public DependentColumnFilter(final byte[] family,
+                               final byte[] qualifier,
+                               final boolean dropDependentColumn,
+                               final CompareOp valueCompareOp,
+                               final FilterComparator valueComparator) {
+    super(valueCompareOp, valueComparator);
+    this.family = family;
+    this.qualifier = qualifier;
+    this.drop_dependent_column = dropDependentColumn;
+  }
+
+  /**
+   * Create a DependentColumnFilter with the provided dependent column, and
+   * specify whether the dependent column should be included in the results.
+   *
+   * @param family of dependent column.
+   * @param qualifier of dependent column.
+   * @param dropDependentColumn whether to include or exclude the dependent
+   *            column in the results.
+   */
+  public DependentColumnFilter(final byte[] family,
+                               final byte[] qualifier,
+                               final boolean dropDependentColumn) {
+    this(family, qualifier, dropDependentColumn, CompareOp.NO_OP, NO_COMPARATOR);
+  }
+
+  /**
+   * Create a DependentColumnFilter with the provided dependent column, and
+   * dependent-column value comparison filter.
+   *
+   * @param family of dependent column.
+   * @param qualifier of dependent column.
+   * @param valueCompareOp of value filter.
+   * @param valueComparator of value filter.
+   */
+  public DependentColumnFilter(final byte[] family,
+                               final byte[] qualifier,
+                               final CompareOp valueCompareOp,
+                               final FilterComparator valueComparator) {
+    this(family, qualifier, false, valueCompareOp, valueComparator);
+  }
+
+  /**
+   * Create a DependentColumnFilter with the provided dependent column.
+   *
+   * @param family of dependent column.
+   * @param qualifier of dependent column
+   */
+  public DependentColumnFilter(final byte[] family,
+                               final byte[] qualifier) {
+    this(family, qualifier, false);
+  }
+
+  /**
+   * Returns the column family of the dependent column.
+   * @return the dependent column's family.
+   */
+  public byte[] family() {
+    return family.clone();
+  }
+
+  /**
+   * Returns the qualifier of the dependent column.
+   * @return the dependent column's qualifier.
+   */
+  public byte[] qualifier() {
+    return qualifier.clone();
+  }
+
+  /**
+   * Returns whether the dependent column will be included in the results.
+   */
+  public boolean dropDependentColumn() {
+    return drop_dependent_column;
+  }
+
+  @Override
+  byte[] name() {
+    return NAME;
+  }
+
+  @Override
+  byte[] serialize() {
+    return FilterPB
+        .DependentColumnFilter
+        .newBuilder()
+        .setCompareFilter(toProtobuf())
+        .setColumnFamily(Bytes.wrap(family))
+        .setColumnQualifier(Bytes.wrap(qualifier))
+        .setDropDependentColumn(drop_dependent_column)
+        .build()
+        .toByteArray();
+  }
+
+  @Override
+  void serializeOld(ChannelBuffer buf) {
+    super.serializeOld(buf);                            // super.predictSerializedSize
+    HBaseRpc.writeByteArray(buf, family);               // 3 + family.length
+    HBaseRpc.writeByteArray(buf, qualifier);            // 3 + qualifier.length
+    buf.writeByte(drop_dependent_column ? 0x01 : 0x00); // 1
+  }
+
+  @Override
+  int predictSerializedSize() {
+    return super.predictSerializedSize()
+        + 3 + family.length
+        + 3 + qualifier.length
+        + 1;
+  }
+
+  @Override
+  public String toString() {
+    return String.format("%s(%s, %s, %s, %s, %s)",
+        getClass().getSimpleName(),
+        Bytes.pretty(family),
+        Bytes.pretty(qualifier),
+        drop_dependent_column,
+        compare_op.name(),
+        comparator.toString());
+  }
+
+  // HBase uses a null in place of this value, but that is and was an awful idea.
+  private static final FilterComparator NO_COMPARATOR = new FilterComparator() {
+    @Override
+    byte[] name() {
+      return new byte[0];
+    }
+
+    @Override
+    ComparatorPB.Comparator toProtobuf() {
+      return null;
+    }
+
+    @Override
+    void serializeOld(ChannelBuffer buf) {
+      // It's unclear why the order is different here, but it is.
+      buf.writeByte(14);    // Writable class code        // 1
+      buf.writeByte(17);    // NullInstance class code    // 1
+      super.serializeOld(buf);                            // super.predictSerializedSize()
+    }
+
+    @Override
+    int predictSerializedSize() {
+      return 1 + 1 + super.predictSerializedSize();
+    }
+
+    @Override
+    public String toString() {
+      return getClass().getSimpleName();
+    }
+  };
+}

--- a/src/FamilyFilter.java
+++ b/src/FamilyFilter.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2012  The Async HBase Authors.  All rights reserved.
+ * This file is part of Async HBase.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *   - Redistributions of source code must retain the above copyright notice,
+ *     this list of conditions and the following disclaimer.
+ *   - Redistributions in binary form must reproduce the above copyright notice,
+ *     this list of conditions and the following disclaimer in the documentation
+ *     and/or other materials provided with the distribution.
+ *   - Neither the name of the StumbleUpon nor the names of its contributors
+ *     may be used to endorse or promote products derived from this software
+ *     without specific prior written permission.
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hbase.async;
+
+import org.hbase.async.generated.FilterPB;
+
+/**
+ * Filter columns based on the column family. Takes an operator (equal, greater,
+ * not equal, etc). and a filter comparator.
+ * @since 1.5
+ */
+public class FamilyFilter extends CompareFilter {
+
+  private static final byte[] NAME =
+      Bytes.UTF8("org.apache.hadoop.hbase.filter.FamilyFilter");
+
+  public FamilyFilter(final CompareOp familyCompareOp,
+                      final FilterComparator familyComparator) {
+    super(familyCompareOp, familyComparator);
+  }
+
+  @Override
+  byte[] name() {
+    return NAME;
+  }
+
+  @Override
+  byte[] serialize() {
+    return FilterPB
+        .FamilyFilter
+        .newBuilder()
+        .setCompareFilter(toProtobuf())
+        .build()
+        .toByteArray();
+  }
+
+}

--- a/src/FilterComparator.java
+++ b/src/FilterComparator.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright (C) 2013  The Async HBase Authors.  All rights reserved.
+ * This file is part of Async HBase.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *   - Redistributions of source code must retain the above copyright notice,
+ *     this list of conditions and the following disclaimer.
+ *   - Redistributions in binary form must reproduce the above copyright notice,
+ *     this list of conditions and the following disclaimer in the documentation
+ *     and/or other materials provided with the distribution.
+ *   - Neither the name of the StumbleUpon nor the names of its contributors
+ *     may be used to endorse or promote products derived from this software
+ *     without specific prior written permission.
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hbase.async;
+
+import com.google.protobuf.ByteString;
+import org.jboss.netty.buffer.ChannelBuffer;
+
+import org.hbase.async.generated.ComparatorPB;
+
+/**
+ * Abstract base class for {@link org.hbase.async.ScanFilter}
+ * comparators.
+ * <p>
+ * These comparators are used by scan filters.
+ * <p>
+ * Subclasses are guaranteed to be immutable and are thus
+ * thread-safe as well as usable concurrently on multiple
+ * {@link org.hbase.async.Scanner} instances.
+ * @since 1.5
+ */
+public abstract class FilterComparator {
+
+  // This class is the equivalent of HBase's WritableByteArrayComparable.
+  // We don't need this class to be Writable or Comparable, so FilterComparator
+  // is a more appropriate name.
+
+  final static byte CODE = 54;
+
+  /**
+   * Returns the name of this scanner on the wire.
+   * <p>
+   * This method is only used with HBase 0.95 and newer.
+   * The contents of the array returned MUST NOT be modified.
+   */
+  abstract byte[] name();
+
+  /**
+   * Serializes the byte representation to a protobuf in a byte array.
+   * <p>
+   * This method is only used with HBase 0.95 and newer.
+   */
+  abstract ComparatorPB.Comparator toProtobuf();
+
+  /**
+   * Wraps the passed in serialized FilterComparator in a protobuf Comparator.
+   *
+   * @param comparator serialized FilterComparator.
+   * @return a serialized protobuf Comparator
+   */
+  protected final ComparatorPB.Comparator toProtobuf(ByteString comparator) {
+    return ComparatorPB
+      .Comparator
+      .newBuilder()
+      .setNameBytes(Bytes.wrap(name()))
+      .setSerializedComparator(comparator)
+      .build();
+  }
+
+  /**
+   * Serializes the byte representation to the RPC channel buffer.
+   * <p>
+   * This method is only used with HBase 0.94 and before.
+   * @param buf The RPC channel buffer to which the byte array is serialized
+   */
+  void serializeOld(ChannelBuffer buf) {
+    buf.writeByte(CODE);  // 1
+  }
+
+  /**
+   * returns the number of bytes that it will write to the RPC channel buffer when {@code serialize}
+   * is called. This method helps predict the initial size of the byte array
+   * <p>
+   * This method is only used with HBase 0.94 and before.
+   * @return A strictly positive integer
+   */
+  int predictSerializedSize() {
+    return 1;
+  }
+}

--- a/src/QualifierFilter.java
+++ b/src/QualifierFilter.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2012  The Async HBase Authors.  All rights reserved.
+ * This file is part of Async HBase.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *   - Redistributions of source code must retain the above copyright notice,
+ *     this list of conditions and the following disclaimer.
+ *   - Redistributions in binary form must reproduce the above copyright notice,
+ *     this list of conditions and the following disclaimer in the documentation
+ *     and/or other materials provided with the distribution.
+ *   - Neither the name of the StumbleUpon nor the names of its contributors
+ *     may be used to endorse or promote products derived from this software
+ *     without specific prior written permission.
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hbase.async;
+
+import org.hbase.async.generated.FilterPB;
+
+/**
+ * Filter columns based on the qualifier. Takes an operator (equal, greater,
+ * not equal, etc). and a filter comparator.
+ * @since 1.5
+ */
+public class QualifierFilter extends CompareFilter {
+
+  private static final byte[] NAME =
+      Bytes.UTF8("org.apache.hadoop.hbase.filter.QualifierFilter");
+
+  public QualifierFilter(final CompareOp op,
+                         final FilterComparator qualifierComparator) {
+    super(op, qualifierComparator);
+  }
+
+  @Override
+  byte[] name() {
+    return NAME;
+  }
+
+  @Override
+  byte[] serialize() {
+    return FilterPB
+        .QualifierFilter
+        .newBuilder()
+        .setCompareFilter(toProtobuf())
+        .build()
+        .toByteArray();
+  }
+}

--- a/src/RegexStringComparator.java
+++ b/src/RegexStringComparator.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright (C) 2012  The Async HBase Authors.  All rights reserved.
+ * This file is part of Async HBase.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *   - Redistributions of source code must retain the above copyright notice,
+ *     this list of conditions and the following disclaimer.
+ *   - Redistributions in binary form must reproduce the above copyright notice,
+ *     this list of conditions and the following disclaimer in the documentation
+ *     and/or other materials provided with the distribution.
+ *   - Neither the name of the StumbleUpon nor the names of its contributors
+ *     may be used to endorse or promote products derived from this software
+ *     without specific prior written permission.
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hbase.async;
+
+import java.nio.charset.Charset;
+
+import com.google.common.base.Charsets;
+import com.google.protobuf.ByteString;
+import org.jboss.netty.buffer.ChannelBuffer;
+
+import org.hbase.async.generated.ComparatorPB;
+
+/**
+ * A regular expression comparator used in comparison filters such as RowFilter,
+ * QualifierFilter, and ValueFilter.
+ * <p>
+ * Don't use an expensive regular expression, because Java's implementation
+ * uses backtracking and matching will happen on the server side, potentially
+ * on many many row keys, columns, or values.
+ * See <a href="http://swtch.com/~rsc/regexp/regexp1.html">Regular Expression
+ * Matching Can Be Simple And Fast</a> for more details on regular expression
+ * performance (or lack thereof) and what "backtracking" means.
+ * <p>
+ * This means you need to <strong>be careful</strong> about using regular
+ * expressions supplied by users as that would allow them to easily DDoS
+ * HBase by sending prohibitively expensive regexps that would consume all
+ * CPU cycles and cause the entire HBase node to time out.
+ * <p>
+ * Only EQUAL and NOT_EQUAL comparisons are valid with this comparator.
+ * @since 1.5
+ */
+public class RegexStringComparator extends FilterComparator {
+
+  private static final byte[] NAME =
+      Bytes.UTF8("org.apache.hadoop.hbase.filter.RegexStringComparator");
+
+  private final String expr;
+  private final Charset charset;
+
+  /**
+   * Create a regular expression filter with the specified regular expression.
+   * <p>
+   * This is equivalent to calling {@link #RegexStringComparator(String, Charset)}
+   * with the UTF-8 charset in argument.
+   *
+   * @param expr The regular expression with which to filter.
+   */
+  public RegexStringComparator(String expr) {
+    this(expr, Charsets.UTF_8);
+  }
+
+  /**
+   * Create a regular expression filter with the specified regular expression
+   * and charset.
+   *
+   * @param expr The regular expression with which to filter.
+   */
+  public RegexStringComparator(String expr, Charset charset) {
+    this.expr = expr;
+    this.charset = charset;
+  }
+
+  public String expression() {
+    return expr;
+  }
+
+  public Charset charset() {
+    return charset;
+  }
+
+  @Override
+  byte[] name() {
+    return NAME;
+  }
+
+  @Override
+  ComparatorPB.Comparator toProtobuf() {
+    ByteString byte_string = ComparatorPB
+      .RegexStringComparator
+      .newBuilder()
+      .setPattern(expr)
+      .setCharset(charset.name())
+      .build()
+      .toByteString();
+    return super.toProtobuf(byte_string);
+  }
+
+  @Override
+  void serializeOld(ChannelBuffer buf) {
+    super.serializeOld(buf);                            // super.predictSerializedSize()
+    // Write code
+    buf.writeByte(0);                                   // 1
+    buf.writeByte((byte) NAME.length);                  // 1
+    buf.writeBytes(NAME);                               // NAME.length
+    // writeUTF the expr
+    byte[] expr_bytes = Bytes.UTF8(expr);
+    buf.writeShort(expr_bytes.length);                  // 2
+    buf.writeBytes(expr_bytes);                         // expr.length
+    // writeUTF the charset
+    byte[] charset_bytes = Bytes.UTF8(charset.name());
+    buf.writeShort(charset_bytes.length);               // 2
+    buf.writeBytes(charset_bytes);                      // charset.length
+  }
+
+  @Override
+  int predictSerializedSize() {
+    return super.predictSerializedSize()
+        + 1 + 1 + NAME.length
+        + 2 + Bytes.UTF8(expr).length
+        + 2 + Bytes.UTF8(charset.name()).length;
+  }
+
+  @Override
+  public String toString() {
+    return String.format("%s(%s, %s)",
+        getClass().getSimpleName(),
+        expr,
+        charset.name());
+  }
+}

--- a/src/RowFilter.java
+++ b/src/RowFilter.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2012  The Async HBase Authors.  All rights reserved.
+ * This file is part of Async HBase.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *   - Redistributions of source code must retain the above copyright notice,
+ *     this list of conditions and the following disclaimer.
+ *   - Redistributions in binary form must reproduce the above copyright notice,
+ *     this list of conditions and the following disclaimer in the documentation
+ *     and/or other materials provided with the distribution.
+ *   - Neither the name of the StumbleUpon nor the names of its contributors
+ *     may be used to endorse or promote products derived from this software
+ *     without specific prior written permission.
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hbase.async;
+
+import org.hbase.async.generated.FilterPB;
+
+/**
+ * Filter rows based on the rowkey. Takes an operator (equal, greater,
+ * not equal, etc). and a filter comparator.
+ * @since 1.5
+ */
+public class RowFilter extends CompareFilter {
+
+  private static final byte[] NAME =
+      Bytes.UTF8("org.apache.hadoop.hbase.filter.RowFilter");
+
+  public RowFilter(final CompareOp rowCompareOp,
+                   final FilterComparator rowComparator) {
+    super(rowCompareOp, rowComparator);
+  }
+
+  @Override
+  byte[] name() {
+    return NAME;
+  }
+
+  @Override
+  byte[] serialize() {
+    return FilterPB
+        .RowFilter
+        .newBuilder()
+        .setCompareFilter(toProtobuf())
+        .build()
+        .toByteArray();
+  }
+}

--- a/src/SubstringComparator.java
+++ b/src/SubstringComparator.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (C) 2012  The Async HBase Authors.  All rights reserved.
+ * This file is part of Async HBase.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *   - Redistributions of source code must retain the above copyright notice,
+ *     this list of conditions and the following disclaimer.
+ *   - Redistributions in binary form must reproduce the above copyright notice,
+ *     this list of conditions and the following disclaimer in the documentation
+ *     and/or other materials provided with the distribution.
+ *   - Neither the name of the StumbleUpon nor the names of its contributors
+ *     may be used to endorse or promote products derived from this software
+ *     without specific prior written permission.
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hbase.async;
+
+import com.google.protobuf.ByteString;
+import org.jboss.netty.buffer.ChannelBuffer;
+
+import org.hbase.async.generated.ComparatorPB;
+
+/**
+ * A substring comparator used in comparison filters such as RowFilter,
+ * QualifierFilter, and ValueFilter. A Substring comparator matches any value
+ * which contains the provided substring.
+ * <p>
+ * Only EQUAL and NOT_EQUAL comparisons are valid with this comparator.
+ * @since 1.5
+ */
+public class SubstringComparator extends FilterComparator {
+
+  private static final byte[] NAME =
+      Bytes.UTF8("org.apache.hadoop.hbase.filter.SubstringComparator");
+
+  private final String substr;
+
+  public SubstringComparator(String substr) {
+    this.substr = substr;
+  }
+
+  public String substring() {
+    return this.substr;
+  }
+
+  @Override
+  byte[] name() {
+    return NAME;
+  }
+
+  @Override
+  ComparatorPB.Comparator toProtobuf() {
+    ByteString byte_string = ComparatorPB
+        .SubstringComparator
+        .newBuilder()
+        .setSubstr(substr)
+        .build()
+        .toByteString();
+    return super.toProtobuf(byte_string);
+  }
+
+  @Override
+  void serializeOld(ChannelBuffer buf) {
+    super.serializeOld(buf);                 // super.predictSerializedSize()
+    // Write code
+    buf.writeByte(0);                        // 1
+    buf.writeByte((byte) NAME.length);       // 1
+    buf.writeBytes(NAME);                    // NAME.length
+    // writeUTF the substring
+    byte[] expr_bytes = Bytes.UTF8(substr);
+    buf.writeShort(expr_bytes.length);       // 2
+    buf.writeBytes(expr_bytes);              // expr.length
+  }
+
+  @Override
+  int predictSerializedSize() {
+    return super.predictSerializedSize()
+        + 1 + 1 + NAME.length
+        + 2 + Bytes.UTF8(substr).length;
+  }
+
+  @Override
+  public String toString() {
+    return String.format("%s(%s)", getClass().getSimpleName(), substr);
+  }
+}

--- a/src/ValueFilter.java
+++ b/src/ValueFilter.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2012  The Async HBase Authors.  All rights reserved.
+ * This file is part of Async HBase.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *   - Redistributions of source code must retain the above copyright notice,
+ *     this list of conditions and the following disclaimer.
+ *   - Redistributions in binary form must reproduce the above copyright notice,
+ *     this list of conditions and the following disclaimer in the documentation
+ *     and/or other materials provided with the distribution.
+ *   - Neither the name of the StumbleUpon nor the names of its contributors
+ *     may be used to endorse or promote products derived from this software
+ *     without specific prior written permission.
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hbase.async;
+
+import org.hbase.async.generated.FilterPB;
+
+/**
+ * Filter key values based on their value. Takes an operator (equal, greater,
+ * not equal, etc). and a filter comparator.
+ * @since 1.5
+ */
+public class ValueFilter extends CompareFilter {
+
+  private static final byte[] NAME =
+      Bytes.UTF8("org.apache.hadoop.hbase.filter.ValueFilter");
+
+  public ValueFilter(final CompareOp valueCompareOp,
+                      final FilterComparator valueComparator) {
+    super(valueCompareOp, valueComparator);
+  }
+
+  @Override
+  byte[] name() {
+    return NAME;
+  }
+
+  @Override
+  byte[] serialize() {
+    return FilterPB
+        .ValueFilter
+        .newBuilder()
+        .setCompareFilter(toProtobuf())
+        .build()
+        .toByteArray();
+  }
+}

--- a/test/TestIntegration.java
+++ b/test/TestIntegration.java
@@ -57,16 +57,23 @@ import org.powermock.reflect.Whitebox;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 
 import com.stumbleupon.async.Callback;
 import com.stumbleupon.async.Deferred;
 import com.stumbleupon.async.DeferredGroupException;
 
 import org.hbase.async.AtomicIncrementRequest;
+import org.hbase.async.BinaryComparator;
+import org.hbase.async.BinaryPrefixComparator;
+import org.hbase.async.BitComparator;
 import org.hbase.async.Bytes;
 import org.hbase.async.ColumnPrefixFilter;
 import org.hbase.async.ColumnRangeFilter;
+import org.hbase.async.CompareFilter.CompareOp;
 import org.hbase.async.DeleteRequest;
+import org.hbase.async.DependentColumnFilter;
+import org.hbase.async.FamilyFilter;
 import org.hbase.async.FilterList;
 import org.hbase.async.GetRequest;
 import org.hbase.async.HBaseClient;
@@ -74,9 +81,14 @@ import org.hbase.async.KeyRegexpFilter;
 import org.hbase.async.KeyValue;
 import org.hbase.async.NoSuchColumnFamilyException;
 import org.hbase.async.PutRequest;
+import org.hbase.async.QualifierFilter;
+import org.hbase.async.RegexStringComparator;
+import org.hbase.async.RowFilter;
 import org.hbase.async.ScanFilter;
 import org.hbase.async.Scanner;
+import org.hbase.async.SubstringComparator;
 import org.hbase.async.TableNotFoundException;
+import org.hbase.async.ValueFilter;
 
 import org.hbase.async.test.Common;
 
@@ -693,6 +705,172 @@ final public class TestIntegration {
     kvs = rows.get(1);
     assertSizeIs(1, kvs);
     assertEq("v3", kvs.get(0).value());
+  }
+
+  @Test
+  public void filterComparators() throws Exception {
+    client.setFlushInterval(FAST_FLUSH);
+    final PutRequest put1 = new PutRequest(table, "fc1", family, "a", "v1");
+    final PutRequest put2 = new PutRequest(table, "fc2", family, "a", "v2");
+    final PutRequest put3 = new PutRequest(table, "fc3", family, "a", "v3");
+    Deferred.group(client.put(put1), client.put(put2), client.put(put3)).join();
+
+    final Scanner binary_scanner = client.newScanner(table);
+    binary_scanner.setStartKey("fc1");
+    binary_scanner.setStopKey("fc4");
+    binary_scanner.setFilter(
+        new RowFilter(CompareOp.LESS, new BinaryComparator(Bytes.UTF8("fc2"))));
+    final ArrayList<ArrayList<KeyValue>> binary_rows =
+        binary_scanner.nextRows().join();
+    assertSizeIs(1, binary_rows);
+    assertSizeIs(1, binary_rows.get(0));
+    assertEq("v1", binary_rows.get(0).get(0).value());
+
+    final Scanner prefix_scanner = client.newScanner(table);
+    prefix_scanner.setStartKey("fc1");
+    prefix_scanner.setStopKey("fc4");
+    prefix_scanner.setFilter(
+        new RowFilter(CompareOp.GREATER_OR_EQUAL,
+            new BinaryPrefixComparator(Bytes.UTF8("fc2"))));
+    final ArrayList<ArrayList<KeyValue>> prefix_rows =
+        prefix_scanner.nextRows().join();
+    assertSizeIs(2, prefix_rows);
+    assertSizeIs(1, prefix_rows.get(0));
+    assertEq("v2", prefix_rows.get(0).get(0).value());
+    assertSizeIs(1, prefix_rows.get(1));
+    assertEq("v3", prefix_rows.get(1).get(0).value());
+
+    final Scanner bit_scanner = client.newScanner(table);
+    bit_scanner.setStartKey("fc1");
+    bit_scanner.setStopKey("fc4");
+    bit_scanner.setFilter(
+        new RowFilter(CompareOp.EQUAL,
+            new BitComparator(Bytes.UTF8("fc2"), BitComparator.BitwiseOp.XOR)));
+    final ArrayList<ArrayList<KeyValue>> bit_rows =
+        bit_scanner.nextRows().join();
+    assertSizeIs(2, bit_rows);
+    assertSizeIs(1, bit_rows.get(0));
+    assertEq("v1", bit_rows.get(0).get(0).value());
+    assertSizeIs(1, bit_rows.get(1));
+    assertEq("v3", bit_rows.get(1).get(0).value());
+
+    final Scanner regex_scanner = client.newScanner(table);
+    regex_scanner.setStartKey("fc1");
+    regex_scanner.setStopKey("fc4");
+    regex_scanner.setFilter(
+        new RowFilter(CompareOp.EQUAL, new RegexStringComparator("fc2")));
+    final ArrayList<ArrayList<KeyValue>> regex_rows =
+        regex_scanner.nextRows().join();
+    assertSizeIs(1, regex_rows);
+    assertSizeIs(1, regex_rows.get(0));
+    assertEq("v2", regex_rows.get(0).get(0).value());
+
+    final Scanner substring_scanner = client.newScanner(table);
+    substring_scanner.setStartKey("fc1");
+    substring_scanner.setStopKey("fc4");
+    substring_scanner.setFilter(
+        new RowFilter(CompareOp.EQUAL, new SubstringComparator("2")));
+    final ArrayList<ArrayList<KeyValue>> substring_rows =
+        substring_scanner.nextRows().join();
+    assertSizeIs(1, substring_rows);
+    assertSizeIs(1, substring_rows.get(0));
+    assertEq("v2", substring_rows.get(0).get(0).value());
+  }
+
+  @Test
+  public void compareFilters() throws Exception {
+    client.setFlushInterval(FAST_FLUSH);
+    final PutRequest put1 = new PutRequest(table, "cf1", family, "a", "v1");
+    final PutRequest put2 = new PutRequest(table, "cf2", family, "b", "v2");
+    final PutRequest put3 = new PutRequest(
+        Bytes.UTF8(table),
+        Bytes.UTF8("cf3"),
+        Bytes.UTF8(family),
+        Bytes.UTF8("c"),
+        Bytes.UTF8("v3"),
+        42);
+    final PutRequest put4 = new PutRequest(
+        Bytes.UTF8(table),
+        Bytes.UTF8("cf3"),
+        Bytes.UTF8(family),
+        Bytes.UTF8("dep"),
+        Bytes.UTF8("v4"),
+        42);
+    Deferred.group(
+        Deferred.group(client.put(put1), client.put(put2)),
+        Deferred.group(client.put(put3), client.put(put4))).join();
+
+    final Scanner row_scanner = client.newScanner(table);
+    row_scanner.setStartKey("cf1");
+    row_scanner.setStopKey("cf4");
+    row_scanner.setFilter(
+        new RowFilter(CompareOp.NOT_EQUAL, new BinaryComparator(Bytes.UTF8("cf2"))));
+    final ArrayList<ArrayList<KeyValue>> row_rows =
+        row_scanner.nextRows().join();
+    assertSizeIs(2, row_rows);
+    assertSizeIs(1, row_rows.get(0));
+    assertEq("v1", row_rows.get(0).get(0).value());
+    assertSizeIs(2, row_rows.get(1));
+    assertEq("v3", row_rows.get(1).get(0).value());
+    assertEq("v4", row_rows.get(1).get(1).value());
+
+    final Scanner family_scanner = client.newScanner(table);
+    family_scanner.setFilter(
+        new FamilyFilter(CompareOp.LESS_OR_EQUAL,
+            new BinaryComparator(Bytes.UTF8("aSomeOtherFamily"))));
+    final ArrayList<ArrayList<KeyValue>> family_rows =
+        family_scanner.nextRows().join();
+    assertNull(family_rows);
+
+    final Scanner qualifier_scanner = client.newScanner(table);
+    qualifier_scanner.setStartKey("cf1");
+    qualifier_scanner.setStopKey("cf4");
+    qualifier_scanner.setFilter(
+        new QualifierFilter(CompareOp.GREATER,
+            new BinaryComparator(Bytes.UTF8("b"))));
+    final ArrayList<ArrayList<KeyValue>> qualifier_rows =
+        qualifier_scanner.nextRows().join();
+    assertSizeIs(1, qualifier_rows);
+    assertSizeIs(2, qualifier_rows.get(0));
+    assertEq("v3", qualifier_rows.get(0).get(0).value());
+    assertEq("v4", qualifier_rows.get(0).get(1).value());
+
+    final Scanner value_scanner = client.newScanner(table);
+    value_scanner.setStartKey("cf1");
+    value_scanner.setStopKey("cf4");
+    value_scanner.setFilter(
+        new ValueFilter(CompareOp.GREATER_OR_EQUAL,
+            new BinaryComparator(Bytes.UTF8("v3"))));
+    final ArrayList<ArrayList<KeyValue>> value_rows =
+        value_scanner.nextRows().join();
+    assertSizeIs(1, value_rows);
+    assertSizeIs(2, value_rows.get(0));
+    assertEq("v3", value_rows.get(0).get(0).value());
+    assertEq("v4", value_rows.get(0).get(1).value());
+
+    final Scanner dependent_scanner = client.newScanner(table);
+    dependent_scanner.setFilter(
+        new DependentColumnFilter(Bytes.UTF8(family), Bytes.UTF8("dep")));
+    final ArrayList<ArrayList<KeyValue>> dependent_rows =
+        dependent_scanner.nextRows().join();
+    assertSizeIs(1, dependent_rows);
+    assertSizeIs(2, dependent_rows.get(0));
+    assertEq("v3", dependent_rows.get(0).get(0).value());
+    assertEq("v4", dependent_rows.get(0).get(1).value());
+
+    final Scanner dependent_value_scanner = client.newScanner(table);
+    dependent_value_scanner.setFilter(
+        new DependentColumnFilter(
+            Bytes.UTF8(family),
+            Bytes.UTF8("dep"),
+            true,
+            CompareOp.EQUAL,
+            new BinaryComparator(Bytes.UTF8("v4"))));
+    final ArrayList<ArrayList<KeyValue>> dependent_value_rows =
+        dependent_value_scanner.nextRows().join();
+    assertSizeIs(1, dependent_value_rows);
+    assertSizeIs(1, dependent_value_rows.get(0));
+    assertEq("v3", dependent_value_rows.get(0).get(0).value());
   }
 
   /** Simple column filter list tests.  */


### PR DESCRIPTION
This change adds the full suite of HBase comparison filters to asynchbase.  `KeyRegexpFilter` should be considered for deprecation / removal, as it is superseded by `RowFilter`/`RegexStringComparator`.  The integration tests pass against HBase 0.94.6-cdh4.3.0, but fail against 0.96.1-hadoop1 while executing the `DependentColumnFilter` tests in `TestIntegration` with the following stacktrace:

``` JAVA
compareFilters(org.hbase.async.test.TestIntegration): java.io.IOException: Cannot set batch on a scan using a filter that returns true for filter.hasFilterRow
        at org.apache.hadoop.hbase.ipc.RpcServer.call(RpcServer.java:2210)
        at org.apache.hadoop.hbase.ipc.RpcServer$Handler.run(RpcServer.java:1876)
Caused by: org.apache.hadoop.hbase.filter.IncompatibleFilterException: Cannot set batch on a scan using a filter that returns true for filter.hasFilterRow
        at org.apache.hadoop.hbase.client.Scan.setBatch(Scan.java:353)
        at org.apache.hadoop.hbase.protobuf.ProtobufUtil.toScan(ProtobufUtil.java:888)
        at org.apache.hadoop.hbase.regionserver.HRegionServer.scan(HRegionServer.java:2980)
        at org.apache.hadoop.hbase.protobuf.generated.ClientProtos$ClientService$2.callBlockingMethod(ClientProtos.java:26929)
        at org.apache.hadoop.hbase.ipc.RpcServer.call(RpcServer.java:2172)
```

My best guess is that this happens because `Scanner` always sets `max_num_kvs`.  Is there a way to disable this?
